### PR TITLE
Validate timeline year and add genres endpoint

### DIFF
--- a/controllers/api/movies/genres.js
+++ b/controllers/api/movies/genres.js
@@ -1,0 +1,18 @@
+import { Router } from "express";
+import { handleError } from "../../../lib/utils";
+import { Genre } from "../../../models";
+
+const router = Router();
+
+router.get("/", async (req, res) => {
+  try {
+    const genres = await Genre.findAll({
+      order: [["id", "ASC"]],
+    });
+    res.json({ success: true, genres: genres.map((g) => g.name) });
+  } catch (err) {
+    handleError(err, res);
+  }
+});
+
+export default router;

--- a/controllers/api/timeline.js
+++ b/controllers/api/timeline.js
@@ -8,9 +8,18 @@ import sequelize from "../../config/connection";
 
 const router = Router();
 
+const yearRegex = /^(\d{4})$/;
+
 router.get("/:year", async (req, res) => {
   let genres = [];
   let include = [];
+  if (!req.params.year.match(yearRegex))
+    return res.status(400).json({ success: false, errors: ["Invalid year"] });
+  const year = parseInt(req.params.year);
+  if (year < 2000 || year > 2023)
+    return res
+      .status(400)
+      .json({ success: false, errors: ["Year must be between 2000 and 2023"] });
   if (req.query.genres) {
     const validGenres = (
       await Genre.findAll({
@@ -49,8 +58,6 @@ router.get("/:year", async (req, res) => {
         "genres",
       ],
     });
-    const date = new Date();
-    date.getDate;
     res.json({
       success: true,
       events: movies.map((m) => ({


### PR DESCRIPTION
This pull request validates the year passed to /api/timeline/:year, and adds a new /api/movies/genres endpoint, which returns all valid genres.